### PR TITLE
Fix `setPeopleProperties` not working on android

### DIFF
--- a/android/src/main/kotlin/com/example/native_mixpanel/NativeMixpanelPlugin.kt
+++ b/android/src/main/kotlin/com/example/native_mixpanel/NativeMixpanelPlugin.kt
@@ -31,7 +31,9 @@ class NativeMixpanelPlugin: MethodCallHandler {
       result.success("Init success..")
 
     } else if(call.method == "identify") {
-      mixpanel?.identify(call.arguments.toString())
+      val id = call.arguments.toString()
+      mixpanel?.identify(id)
+      mixpanel?.people?.identify(id)
       result.success("Identify success..")
 
     } else if(call.method == "alias") {


### PR DESCRIPTION
`setPeopleProperties` uses `mixpanel.people.set`. This does not work
unless the person has been identified with `mixpanel.people.identify`
first. To fix this identify was added to the existing identify
implementation.

See
https://developer.mixpanel.com/docs/android#section-setting-profile-properties
for more details.