### PR TITLE
New method to allow setting people identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,3 +27,6 @@ Force converted arguments to [String:String] type for time being
 # 0.1.0
 - iOS: use SWIFT 4.2
 - Added instruction in Readme for iOS for SWIFT version used
+
+# 0.1.1
+- Added `identifyPeople` to set people identity

--- a/README.md
+++ b/README.md
@@ -12,3 +12,7 @@ If you are getting `java.lang.NoClassDefFoundError` for `FirebaseMessagingServic
 please configure Firebase Cloud Messaging Service in your project.
 
 Refer to this release note: [FCM Support](https://github.com/mixpanel/mixpanel-android/releases/tag/v5.5.0)
+
+### Note
+
+Call `identifyPeople` if you want to set people identity and `identify` if you only want to set id of Mixpanel instance

--- a/android/src/main/kotlin/com/example/native_mixpanel/NativeMixpanelPlugin.kt
+++ b/android/src/main/kotlin/com/example/native_mixpanel/NativeMixpanelPlugin.kt
@@ -33,7 +33,11 @@ class NativeMixpanelPlugin: MethodCallHandler {
     } else if(call.method == "identify") {
       mixpanel?.identify(call.arguments.toString())
       result.success("Identify success..")
-
+    } else if(call.method == "identifyPeople") {
+      val id = call.arguments.toString()
+      mixpanel?.identify(id)
+      mixpanel?.people?.identify(id)
+      result.success("Identify people success..")
     } else if(call.method == "alias") {
       mixpanel?.alias(call.arguments.toString(), mixpanel?.getDistinctId())
       result.success("Alias success..")

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -39,7 +39,7 @@ class _MyAppState extends State<MyApp> {
     String eventName = 'First App Open';
     // Platform messages may fail, so we use a try/catch PlatformException.
     try {
-      await widget.mixpanel.initialize('2500d0d99b3d441c731588f2ef57ef36');
+      await widget.mixpanel.initialize('your-token-here');
       await widget.mixpanel.track(eventName, {'Math': 'divide'});
       initStatus = 'Event Sent: $eventName';
     } on PlatformException {
@@ -81,6 +81,15 @@ class _MyAppState extends State<MyApp> {
                   await widget.mixpanel.identify('101');
                 },
                 child: Text('Set Identity'),
+              ),
+            ),
+            Container(
+              alignment: Alignment.center,
+              child: RaisedButton(
+                onPressed: () async {
+                  await widget.mixpanel.identify('102');
+                },
+                child: Text('Set People Identity'),
               ),
             ),
             Container(

--- a/ios/Classes/SwiftNativeMixpanelPlugin.swift
+++ b/ios/Classes/SwiftNativeMixpanelPlugin.swift
@@ -32,7 +32,9 @@ import Mixpanel
       if (call.method == "initialize") {
         Mixpanel.initialize(token: call.arguments as! String)
       } else if(call.method == "identify") {
-        Mixpanel.mainInstance().identify(distinctId: call.arguments as! String)
+        Mixpanel.mainInstance().identify(distinctId: call.arguments as! String, usePeople: false)
+      } else if (call.method == "identifyPeople") {
+        Mixpanel.mainInstance().identify(distinctId: call.arguments as! String, usePeople: true)
       } else if(call.method == "alias") {
         Mixpanel.mainInstance().createAlias(call.arguments as! String, distinctId: Mixpanel.mainInstance().distinctId)
       } else if(call.method == "setPeopleProperties") {

--- a/lib/native_mixpanel.dart
+++ b/lib/native_mixpanel.dart
@@ -67,6 +67,10 @@ class Mixpanel extends _Mixpanel {
     return this._mp.track('identify', distinctId);
   }
 
+  Future identifyPeople(String distinctId) {
+    return this._mp.track('identifyPeople', distinctId);
+  }
+
   Future alias(String alias) {
     return this._mp.track('alias', alias);
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: native_mixpanel
 description: Plugin for Mixpanel
-version: 0.1.0
+version: 0.1.1
 author: Suren Yonjan <surendrayonjan@gmail.com>
 homepage: https://github.com/truenary/native_mixpanel
 


### PR DESCRIPTION
1. Added `identifyPeople` to explicitly set people identity contrast to `identify` which only set id of Mixpanel session
2. Also fixes bug mentioned in #10 